### PR TITLE
Enable  cards enpoint

### DIFF
--- a/BunqAPI/callbacks.py
+++ b/BunqAPI/callbacks.py
@@ -147,7 +147,7 @@ class callback(AESCipher):
         '''
         url = 'user/%s/card' % self.userID
         r = self.bunq_api.query(
-            '%s/card/%s' % (url, cardID)
+            '%s/%s' % (url, cardID)
         )
         return self.response(r)
 

--- a/BunqAPI/callbacks.py
+++ b/BunqAPI/callbacks.py
@@ -7,7 +7,24 @@ from django.core.exceptions import ObjectDoesNotExist
 
 
 class callback(AESCipher):
-    """docstring for sessoin."""
+    """docstring for sessoin.
+        This class handles the callbacks to the bunq api.
+
+        f = the contents of the users ecnrypted json.
+        api_token = the api token from the bunq app.
+        user = is the currently logged in user.
+        init_api = is the pythonBunq.bunq.api instance before session token
+        userID = is the provided user id that can be used to retrieve data
+                 of a specific user register to the API key.
+        accountID = cardID = id's to retrieve a specific card or account
+                    belonging to the user id.
+        account_url = url used by most endpoints
+        s = is the server session token stored in the django sessoin. The key
+            for this session is sotred in the database, only logged in users
+            can retreive their keys.
+        bunq_api = is the pythonBunq.bunq.api instace after the session token
+                   is retrieved.
+    """
     def __init__(self, f, user, password, userID='', accountID=''):
         AESCipher.__init__(self, password)
         f = self.decrypt(f['secret'])
@@ -147,7 +164,7 @@ class callback(AESCipher):
         '''
         url = 'user/%s/card' % self.userID
         r = self.bunq_api.query(
-            '%s/%s' % (url, cardID)
+            '%s/%s' % (url, self.accountID)
         )
         return self.response(r)
 

--- a/BunqAPI/views.py
+++ b/BunqAPI/views.py
@@ -115,11 +115,11 @@ def decrypt(request):
 
 
 @otp_required
-def API(request, selector, userID='', accountID='', cardID=''):
+def API(request, selector, userID='', accountID=''):
     '''
     Need to use mock test to test this code.
     The view that handles API calls.
-
+    accountID === cardID
     '''
     if request.method == 'POST':
         f = json.loads(request.POST['json'])

--- a/BunqAPI/views.py
+++ b/BunqAPI/views.py
@@ -115,7 +115,7 @@ def decrypt(request):
 
 
 @otp_required
-def API(request, selector, userID='', accountID=''):
+def API(request, selector, userID='', accountID='', cardID=''):
     '''
     Need to use mock test to test this code.
     The view that handles API calls.

--- a/static/BunqAPI/JS/decrypt.js
+++ b/static/BunqAPI/JS/decrypt.js
@@ -87,7 +87,6 @@ function sendPost(json, action, template) {
       // r = response
       // $("#response").html(response)
       if (r.Response) {
-        console.log(r.Response);
         show(r.Response, false, template)
       } else {
         show(r, true)

--- a/static/BunqAPI/JS/decrypt.js
+++ b/static/BunqAPI/JS/decrypt.js
@@ -51,6 +51,8 @@ $(function() {
   });
   $("#card").click(function(event) {
     /* Act on the event */
+    sendPost(jsonObj, $(this)[0].id + '/' + userID + '/' + accountID, card_template)
+    
   });
   $("#mastercard_action").click(function(event) {
     /* Act on the event */
@@ -85,6 +87,7 @@ function sendPost(json, action, template) {
       // r = response
       // $("#response").html(response)
       if (r.Response) {
+        console.log(r.Response);
         show(r.Response, false, template)
       } else {
         show(r, true)

--- a/static/BunqAPI/templates/mustache/card.html
+++ b/static/BunqAPI/templates/mustache/card.html
@@ -7,6 +7,10 @@ Status = {{status}}
 Expire date = {{expiry_date}}
 <br>
 Name on card = {{name_on_card}}
+<br>
+bank account ID = {{label_monetary_account_current.id}}
+<br>
+bank account description  = {{label_monetary_account_current.description}}
 {{/CardDebit}}
 {{/.}}
 {{^.}}

--- a/static/BunqAPI/templates/mustache/card.html
+++ b/static/BunqAPI/templates/mustache/card.html
@@ -1,0 +1,10 @@
+<h3>Cards</h3>
+{{#.}}{{#CardDebit}}
+card ID = {{id}}
+<br>
+Status = {{status}}
+<br>
+Expire date = {{expiry_date}}
+<br>
+Name on card = {{name_on_card}}
+{{/CardDebit}}{{/.}}

--- a/static/BunqAPI/templates/mustache/card.html
+++ b/static/BunqAPI/templates/mustache/card.html
@@ -7,4 +7,8 @@ Status = {{status}}
 Expire date = {{expiry_date}}
 <br>
 Name on card = {{name_on_card}}
-{{/CardDebit}}{{/.}}
+{{/CardDebit}}
+{{/.}}
+{{^.}}
+No cards found
+{{/.}}

--- a/templates/BunqAPI/decrypt.html
+++ b/templates/BunqAPI/decrypt.html
@@ -29,7 +29,7 @@
   </form>
   <div class="">
     <input type="text" name="" value="" placeholder="user ID" id="userID">
-    <input type="text" name="" value="" placeholder="account ID" id="accountID">
+    <input type="text" name="" value="" placeholder="account/card ID" id="accountID">
   </div>
   <div class="">
     <button type="" name="" id="load_file">load file</button>

--- a/templates/BunqAPI/decrypt.html
+++ b/templates/BunqAPI/decrypt.html
@@ -1,3 +1,4 @@
+
 <head>
   {%load static%}
   <script type='text/javascript' src="{%static "js-cookie/src/js.cookie.js "%}"></script>
@@ -10,6 +11,7 @@
     var ussers_template = '{%static 'BunqAPI/templates/mustache/users.html'%}'
     var accounts_template = '{%static 'BunqAPI/templates/mustache/accounts.html'%}'
     var payments_template = '{%static 'BunqAPI/templates/mustache/payments.html'%}'
+    var card_template = '{%static 'BunqAPI/templates/mustache/card.html'%}'
   </script>
 
   <script type='text/javascript' src="{%static "BunqAPI/JS/decrypt.js "%}"></script>


### PR DESCRIPTION
This button was not enabled in #33 this pr will enable it. 

On the decrpyt page there is a box where you can enter an account id, this box will also work for card id's. Same goes for the code that handles these id's. The actual variable is called `accountID` but it is also the `cardID`.

In the sandbox environment there are no cards to test, but I've used an example form the [bunq api docs] to simulate an response.

[bunq api docs]:<https://doc.bunq.com/api/1/call/card/method/get>